### PR TITLE
only look at first part of name when looking for machine

### DIFF
--- a/src/ble/DE1.h
+++ b/src/ble/DE1.h
@@ -171,7 +171,7 @@ class DE1 : public Device, public Machine {
 
   bool shouldConnect(NimBLEAdvertisedDevice* d) {
     // name returned by BLE is null terminated (in a std::string!) so fallback to strcmp
-    return (strcmp(de1_name, d->getName().c_str())) == 0;
+    return (strncmp(de1_name, d->getName().c_str(), strlen(de1_name))) == 0;
   }
   const std::string getName() {
     return de1_name;


### PR DESCRIPTION
Though I don't have one to test with I suspect XL machines advertise with a different name than just `DE1`. When deciding whether to connect, change to only look for names that /start/ with `DE1`
